### PR TITLE
lot 10 paiement :fix Update payment URL parameters in translation files

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -137,14 +137,14 @@ msgstr "No approval and phone number"
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:17
 msgid "policy_notification.sms_request_payment_for_activation_beneficiary"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "AMG: Pay %(AmountToBePaid)s kmf (code %(InsuranceID)s) to activate coverage. "
 "MVola #4441514010318*%(AmountToBePaid)s*%(InsuranceID)s#. Info: 7332135"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:21
 msgid "policy_notification.sms_request_payment_for_paamg"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "A PAAMG policy for the family/group %(InsuranceID)s - %(Name)s with the " 
 "insurance product %(ProductCode)s - %(ProductName)s requires payment of %(AmountToBePaid)s " 
 "for 12 months. Please process the payment."
@@ -153,7 +153,7 @@ msgstr ""
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:25
 msgid "policy_notification.sms_on_periodic_payment"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "Dear beneficiary, this is a reminder that the due date for your contribution "
 "payment is %(DateDue)s."
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -136,7 +136,7 @@ msgstr "Aucune approbation ni numéro de téléphone"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:17
 msgid "policy_notification.sms_request_payment_for_activation_beneficiary"
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 msgstr "AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
 "MVola #4441514010318*%(AmountToBePaid)s*%(InsuranceID)s# ou bdc 10380750002. infos 7332135"
 
@@ -144,7 +144,7 @@ msgstr "AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer vo
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:21
 msgid "policy_notification.sms_request_payment_for_paamg"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "Une police PAAMG pour la famille/groupe %(InsuranceID)s - %(Name)s avec le "
 "produit d'assurance %(ProductCode)s - %(ProductName)s nécessite un paiement de "
 "%(AmountToBePaid)s pour 12 mois. Veuillez effectuer le paiement."
@@ -153,7 +153,7 @@ msgstr ""
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:25
 msgid "policy_notification.sms_on_periodic_payment"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "Cher assuré, nous vous rappelons que la date limite pour le paiement "
 "de votre cotisation est le %(DateDue)s."
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -136,8 +136,9 @@ msgstr "Aucune approbation ni numéro de téléphone"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:17
 msgid "policy_notification.sms_request_payment_for_activation_beneficiary"
+msgstr ""
 "holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
-msgstr "AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
+"AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
 "MVola #4441514010318*%(AmountToBePaid)s*%(InsuranceID)s# ou bdc 10380750002. infos 7332135"
 
 

--- a/locale/fr_KM/LC_MESSAGES/django.po
+++ b/locale/fr_KM/LC_MESSAGES/django.po
@@ -136,14 +136,14 @@ msgstr "Aucune approbation ni numéro de téléphone"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:17
 msgid "policy_notification.sms_request_payment_for_activation_beneficiary"
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 msgstr "AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
 "MVola #4441514010318*%(AmountToBePaid)s*%(InsuranceID)s# ou bdc 10380750002. infos 7332135"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:21
 msgid "policy_notification.sms_request_payment_for_paamg"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "Une police PAAMG pour la famille/groupe %(InsuranceID)s - %(Name)s avec le "
 "produit d'assurance %(ProductCode)s - %(ProductName)s nécessite un paiement de "
 "%(AmountToBePaid)s pour 12 mois. Veuillez effectuer le paiement."
@@ -152,7 +152,7 @@ msgstr ""
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:25
 msgid "policy_notification.sms_on_periodic_payment"
 msgstr ""
-"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimis_ref=%(InsuranceID)s&policy_uuid=%(PolicyUuid)s"
+"holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
 "Cher assuré, nous vous rappelons que la date limite pour le paiement "
 "de votre cotisation est le %(DateDue)s."
 

--- a/locale/fr_KM/LC_MESSAGES/django.po
+++ b/locale/fr_KM/LC_MESSAGES/django.po
@@ -136,8 +136,9 @@ msgstr "Aucune approbation ni numéro de téléphone"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:17
 msgid "policy_notification.sms_request_payment_for_activation_beneficiary"
+msgstr ""
 "holo https://dev.amg.km/amg-pay/payments/initier-paiement?amount=%(AmountToBePaid)s&openimisRef=%(InsuranceID)s&policyUuid=%(PolicyUuid)s"
-msgstr "AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
+"AMG: payez %(AmountToBePaid)s kmf (code %(InsuranceID)s) pour activer votre couverture. "
 "MVola #4441514010318*%(AmountToBePaid)s*%(InsuranceID)s# ou bdc 10380750002. infos 7332135"
 
 #: policy_notification/notification_templates/DefaultNotificationTemplates.py:21


### PR DESCRIPTION
Aparement lorsqu'on a  teste avec le numero de IRSOID le provider de SMS ne supporte pas le charctere "_" et par consequant le lien ne marche pas car il remplace  les "_" avec des " " 


Changed 'openimis_ref' and 'policy_uuid' to 'openimisRef' and 'policyUuid' in payment URLs within English, French, and French (KM) translation files for consistency with updated parameter naming conventions.

